### PR TITLE
Make deprecated warnings dark (Fixes #4)

### DIFF
--- a/DarkDocs Extension/docs.css
+++ b/DarkDocs Extension/docs.css
@@ -46,6 +46,10 @@
     .copy {
         color: var(--sbs-secondary-text-color) !important;
     }
+    
+    aside[data-v-bea67dc0].deprecated {
+        background-color: var(--sbs-secondary-bg-color);
+    }
 
     .symbol-name-decorated .decorator, .symbol-name-decorated .label {
         color: var(--sbs-secondary-text-color) !important;


### PR DESCRIPTION
I added a small CSS rule to make deprecated warnings dark.

Fixes #4 

Screenshot:
![Image of dark deprecated warning](https://i.imgur.com/O8xnoWI.png)